### PR TITLE
Upload MoM revenue graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__*
 
 /google-credentials.json
+/mom_revenue.png

--- a/bigquery.py
+++ b/bigquery.py
@@ -6,6 +6,13 @@ from oauth2client.client import GoogleCredentials
 from utilities.parse_bigquery_data import parse_data
 import pandas as pd
 
+# plotting libraries
+import matplotlib
+matplotlib.use('Agg') # use a non-interactive backend for writing to file
+import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter
+import seaborn as sns
+
 projectId = 'gc-data-warehouse'
 credentials = GoogleCredentials.get_application_default()
 
@@ -25,6 +32,15 @@ def revenue_summary():
     revenue_last_month['revenue_running_sum'] = revenue_last_month.revenue.cumsum()
     return revenue_this_month, revenue_last_month
 
+def generate_revenue_comment(revenue_this_month, revenue_last_month):
+    current_working_day = revenue_this_month.iloc[-1]['working_day']
+    current_revenue = int(revenue_this_month.iloc[-1]['revenue_running_sum'])
+    revenue_this_time_last_month = revenue_last_month.loc[revenue_last_month.working_day == current_working_day, 'revenue_running_sum']
+    revenue_this_time_last_month = int(revenue_this_time_last_month.values[0]) # get cell value
+    percent_mom_difference = round(100*(current_revenue - revenue_this_time_last_month)/revenue_this_time_last_month, 2)
+    comment_template = "So far this month we've generated £{0:,} in revenue, compared to £{1:,} this time last month ({2:+}%)."
+    return comment_template.format(current_revenue, revenue_this_time_last_month, percent_mom_difference)
+
 def run_query(query_filename):
     service = discovery.build('bigquery', 'v2', credentials=credentials)
 
@@ -38,11 +54,27 @@ def run_query(query_filename):
     response = request.execute()
     return parse_data(response['schema'], response['rows'])
 
+def plot_mom_chart(revenue_this_month, revenue_last_month):
+    fig, ax = plt.subplots()
+    ax.yaxis.set_major_formatter(FuncFormatter(_thousands_formatter))
+    plt.plot(revenue_this_month['working_day'], revenue_this_month['revenue_running_sum'], label='This Month')
+    plt.plot(revenue_last_month['working_day'], revenue_last_month['revenue_running_sum'], label='Last Month')
+    plt.xlabel('Working Day')
+    plt.ylabel('Revenue')
+    plt.legend(loc='lower right')
+    fig.savefig('mom_revenue.png')
+
 def _load_query(query_filename):
     with open(os.path.join('queries', query_filename)) as sql_file:
         return sql_file.read()
 
+def _thousands_formatter(x, pos):
+    'The args are the value and tick position'
+    return '£{}k'.format(int(x*1e-3))
+
 if __name__ == "__main__":
-    x, y = revenue_summary()
-    print(x, y)
+    this_month, last_month = revenue_summary()
+    comment = generate_revenue_comment(this_month, last_month)
+    print(comment)
+    plot_mom_chart(this_month, last_month)
 

--- a/databot.py
+++ b/databot.py
@@ -2,13 +2,15 @@ import os
 import time
 from slackclient import SlackClient
 from bigquery import revenue_summary
+from bigquery import plot_mom_chart
+from bigquery import generate_revenue_comment
 from raven import Client
+from slacker import Slacker
 
 BOT_ID = os.environ.get('DATABOT_ID')
+slack_rtm_client = SlackClient(os.environ.get('DATABOT_API_TOKEN'))
+slack = Slacker(os.environ.get('DATABOT_API_TOKEN'))
 
-slack_client = SlackClient(os.environ.get('DATABOT_API_TOKEN'))
-
-databot_messages = []
 
 def parse_slack_output(slack_rtm_output):
     for message in slack_rtm_output:
@@ -17,15 +19,16 @@ def parse_slack_output(slack_rtm_output):
             channel_id = message['channel']
             if 'revenue' in message['text']:
                 revenue_this_month, revenue_last_month = revenue_summary()
-                request = slack_client.api_call("chat.postMessage",
-                                channel=channel_id,
-                                text=round(revenue_this_month.iloc[-1]['revenue_running_sum']),
-                                as_user=True)
+                comment = generate_revenue_comment(revenue_this_month, revenue_last_month)
+                plot_mom_chart(revenue_this_month, revenue_last_month)
+                slack.files.upload('mom_revenue.png',
+                                   filename='Month-on-Month Revenue',
+                                   channels=channel_id,
+                                   initial_comment=comment)
             else:
-                request = slack_client.api_call("chat.postMessage",
-                                                channel=channel_id,
-                                                text='you called?',
-                                                as_user=True)
+                slack.chat.post_message(channel=channel_id,
+                                        text='you called?',
+                                        as_user=True)
         else:
             print(message)
 
@@ -33,13 +36,12 @@ def parse_slack_output(slack_rtm_output):
 if __name__ == '__main__':
 
     try:
-        if slack_client.rtm_connect():
+        if slack_rtm_client.rtm_connect():
             print("websocket open for business")
             while True:
-                parse_slack_output(slack_client.rtm_read())
+                parse_slack_output(slack_rtm_client.rtm_read())
                 time.sleep(1)
         else:
-            # print(slack_client.rtm_connect())
             print('problem with connection')
     except:
         client = Client(os.environ.get('DATABOT_SNITCH_URL'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ google-api-python-client==1.5.1
 slackclient==1.0.1
 pandas==0.18.1
 raven==5.24.3
+matplotlib==1.5.2
+seaborn==0.7.1
+slacker==0.9.24


### PR DESCRIPTION
I used another slack library (`slacker`) to upload the MoM graph to Slack, because it made it easier to upload files than `slack_client`.

For consistency, I've updated the `post_message` command to use `slacker` as well. We still use `slack_client` for the RTM API integration, because `slacker` doesn't do this bit.
